### PR TITLE
Improve Grid Builder UI with inline column editing

### DIFF
--- a/src/components/grid-builder/GridPreview.vue
+++ b/src/components/grid-builder/GridPreview.vue
@@ -145,15 +145,15 @@ const getColumnClasses = (column) => {
 .grid-lines {
   background-image: repeating-linear-gradient(
       90deg,
-      rgba(14, 165, 233, 0.1) 0,
-      rgba(14, 165, 233, 0.1) 1px,
+      rgba(34, 197, 94, 0.25) 0,
+      rgba(34, 197, 94, 0.25) 1px,
       transparent 1px,
       transparent calc(100% / 12)
     ),
     repeating-linear-gradient(
       0deg,
-      rgba(14, 165, 233, 0.1) 0,
-      rgba(14, 165, 233, 0.1) 1px,
+      rgba(34, 197, 94, 0.25) 0,
+      rgba(34, 197, 94, 0.25) 1px,
       transparent 1px,
       transparent 40px
     );
@@ -161,7 +161,7 @@ const getColumnClasses = (column) => {
 }
 
 .preview-col {
-  background: linear-gradient(135deg, #22c55e, #16a34a);
+  background: linear-gradient(135deg, var(--primary-blue), var(--accent-cyan));
   border-radius: 8px;
   padding: 16px;
   min-height: 80px;

--- a/src/views/layout/GridBuilder.vue
+++ b/src/views/layout/GridBuilder.vue
@@ -87,6 +87,7 @@
                 @move-row-down="moveRowDown"
                 @add-column="addColumn"
                 @delete-column="deleteColumn"
+                @update-column="updateColumn"
               />
             </div>
 


### PR DESCRIPTION
Changes:
1. Color scheme adjustments:
   - Preview columns: Back to blue gradient (#0ea5e9 → #06b6d4)
   - Grid lines: Changed to light green (rgba(34, 197, 94, 0.25))
   - More visible grid lines with green color

2. Enhanced Row Management Tab:
   - Added expandable column editing directly in Row tab
   - Click column header to expand/collapse inline editor
   - Number inputs for all 6 breakpoints (XS, SM, MD, LG, XL, XXL)
   - Real-time updates on input change
   - Visual feedback with smooth slide animation
   - Shows current column classes in header

Features:
- Inline editing: No need to switch to Column Management tab
- Quick access: Click any column to edit breakpoint values
- Number inputs: Type 1-12 directly for each breakpoint
- Auto-update: Changes apply immediately to preview
- Compact UI: Only expanded column shows edit controls

Components Updated:
- RowManagementTab.vue: Added inline column editing with number inputs
- GridPreview.vue: Blue columns, green grid lines
- GridBuilder.vue: Added @update-column to Row Management

User Experience:
- Faster workflow with inline editing
- Column Management tab still available for detailed settings
- Better visual distinction with green grid lines