### PR TITLE
Add bulk edit and improve Grid Builder UX

### DIFF
--- a/src/components/grid-builder/GridPreview.vue
+++ b/src/components/grid-builder/GridPreview.vue
@@ -116,12 +116,12 @@ const showGridLines = ref(false)
 const showClassNames = ref(true)
 
 const breakpoints = [
-  { value: 'xs', label: 'Mobile', icon: '📱', description: '< 576px' },
-  { value: 'sm', label: 'Tablet', icon: '📱', description: '≥ 576px' },
-  { value: 'md', label: 'Tablet', icon: '💻', description: '≥ 768px' },
-  { value: 'lg', label: 'Desktop', icon: '💻', description: '≥ 992px' },
-  { value: 'xl', label: 'Desktop', icon: '🖥️', description: '≥ 1200px' },
-  { value: 'xxl', label: 'Wide', icon: '🖥️', description: '≥ 1400px' }
+  { value: 'xs', label: 'Mobile (xs)', icon: '📱', description: '< 576px' },
+  { value: 'sm', label: 'Tablet (sm)', icon: '📱', description: '≥ 576px' },
+  { value: 'md', label: 'Tablet (md)', icon: '💻', description: '≥ 768px' },
+  { value: 'lg', label: 'Desktop (lg)', icon: '💻', description: '≥ 992px' },
+  { value: 'xl', label: 'Desktop (xl)', icon: '🖥️', description: '≥ 1200px' },
+  { value: 'xxl', label: 'Wide (xxl)', icon: '🖥️', description: '≥ 1400px' }
 ]
 
 const getRowClasses = (row) => {


### PR DESCRIPTION
- Add bulk edit input to column headers for one-click updates of all breakpoints
- Implement getMostCommonWidth() to show the most frequently used width value
- Add breakpoint names in parentheses to preview buttons (e.g., "Mobile (xs)")
- Improve inline editing workflow in Row Management tab