### PR TITLE
Fix container demo layout to show proper margins

### DIFF
--- a/src/views/layout/Containers.vue
+++ b/src/views/layout/Containers.vue
@@ -75,7 +75,7 @@
         </p>
 
         <!-- .container -->
-        <div class="mb-4">
+        <div class="mb-5">
           <h3 class="h5 mb-2" style="color: var(--text-primary)">
             <code>.container</code> - レスポンシブな固定幅
           </h3>
@@ -83,17 +83,22 @@
             各ブレークポイントで最大幅が設定されます。中央揃えで表示され、<strong>左右に余白</strong>が生まれます。
           </p>
         </div>
-        <div class="demo-wrapper mb-4">
-          <div class="container demo-container-fixed">
-            <div class="demo-content">
-              <div class="demo-label">.container</div>
-              <div class="demo-width-info">固定幅 + 左右余白あり</div>
-            </div>
+      </section>
+
+      <!-- デモエリア（glass-cardの外） -->
+      <div class="demo-outer-wrapper mb-4">
+        <div class="demo-screen-label">← 画面全体の範囲 →</div>
+        <div class="container demo-container-fixed">
+          <div class="demo-content">
+            <div class="demo-label">.container</div>
+            <div class="demo-width-info">固定幅 + 左右に余白あり（中央揃え）</div>
           </div>
         </div>
+      </div>
 
+      <section class="glass-card p-4 mb-4">
         <!-- .container-fluid -->
-        <div class="mb-4">
+        <div class="mb-5">
           <h3 class="h5 mb-2" style="color: var(--text-primary)">
             <code>.container-fluid</code> - 全幅
           </h3>
@@ -101,17 +106,21 @@
             画面の幅いっぱいに広がります。<strong>左右の余白は最小限</strong>（パディングのみ）です。
           </p>
         </div>
-        <div class="demo-wrapper mb-4">
-          <div class="container-fluid demo-container-fluid">
-            <div class="demo-content">
-              <div class="demo-label">.container-fluid</div>
-              <div class="demo-width-info">画面幅100% + 余白なし</div>
-            </div>
+      </section>
+
+      <div class="demo-outer-wrapper mb-4">
+        <div class="demo-screen-label">← 画面全体の範囲 →</div>
+        <div class="container-fluid demo-container-fluid">
+          <div class="demo-content">
+            <div class="demo-label">.container-fluid</div>
+            <div class="demo-width-info">画面幅100%（パディングのみ）</div>
           </div>
         </div>
+      </div>
 
+      <section class="glass-card p-4 mb-4">
         <!-- .container-{breakpoint} -->
-        <div class="mb-4">
+        <div class="mb-5">
           <h3 class="h5 mb-2" style="color: var(--text-primary)">
             <code>.container-md</code> - ブレークポイント指定
           </h3>
@@ -119,14 +128,19 @@
             指定したブレークポイント（この例ではmd: 768px）までは全幅、それ以降は固定幅になります。
           </p>
         </div>
-        <div class="demo-wrapper mb-4">
-          <div class="container-md demo-container-breakpoint">
-            <div class="demo-content">
-              <div class="demo-label">.container-md</div>
-              <div class="demo-width-info">md未満: 全幅 / md以上: 固定幅</div>
-            </div>
+      </section>
+
+      <div class="demo-outer-wrapper mb-4">
+        <div class="demo-screen-label">← 画面全体の範囲 →</div>
+        <div class="container-md demo-container-breakpoint">
+          <div class="demo-content">
+            <div class="demo-label">.container-md</div>
+            <div class="demo-width-info">md未満: 全幅 / md以上: 固定幅</div>
           </div>
         </div>
+      </div>
+
+      <section class="glass-card p-4 mb-4">
 
         <!-- コード -->
         <div class="code-box">
@@ -476,78 +490,48 @@ onMounted(() => {
 </script>
 
 <style scoped>
-/* デモラッパー - 画面全体の範囲を示す */
-.demo-wrapper {
+/* デモ外側ラッパー - 画面全体の範囲を示す */
+.demo-outer-wrapper {
   background: linear-gradient(135deg, #e5e7eb 0%, #d1d5db 100%);
-  padding: 30px 0;
+  padding: 40px 0;
   border-radius: 12px;
   position: relative;
-  overflow: visible;
   border: 2px solid #9ca3af;
 }
 
-.demo-wrapper::before {
-  content: '← 画面全体の範囲 →';
+.demo-screen-label {
   position: absolute;
-  top: 5px;
+  top: 8px;
   left: 50%;
   transform: translateX(-50%);
-  font-size: 11px;
+  font-size: 12px;
   color: #6b7280;
   font-weight: 600;
   background: white;
-  padding: 2px 12px;
+  padding: 4px 16px;
   border-radius: 12px;
   border: 1px solid #9ca3af;
 }
 
 /* .container デモ */
 .demo-container-fixed {
-  background: rgba(14, 165, 233, 0.15);
+  background: rgba(14, 165, 233, 0.2);
   border: 3px solid var(--primary-blue);
   border-radius: 8px;
-  position: relative;
-}
-
-.demo-container-fixed::before,
-.demo-container-fixed::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 20px;
-  background: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 5px,
-    rgba(239, 68, 68, 0.3) 5px,
-    rgba(239, 68, 68, 0.3) 10px
-  );
-  border: 2px dashed #ef4444;
-}
-
-.demo-container-fixed::before {
-  left: -23px;
-}
-
-.demo-container-fixed::after {
-  right: -23px;
 }
 
 /* .container-fluid デモ */
 .demo-container-fluid {
-  background: rgba(34, 197, 94, 0.15);
+  background: rgba(34, 197, 94, 0.2);
   border: 3px solid #22c55e;
   border-radius: 8px;
-  position: relative;
 }
 
 /* .container-md デモ */
 .demo-container-breakpoint {
-  background: rgba(168, 85, 247, 0.15);
+  background: rgba(168, 85, 247, 0.2);
   border: 3px solid #a855f7;
   border-radius: 8px;
-  position: relative;
 }
 
 .demo-content {


### PR DESCRIPTION
- Move demo areas outside glass-card to allow container margins to display correctly
- Remove visual margin indicators (red dashed patterns)
- Simplify demo structure: each container type now shows actual Bootstrap behavior
- Keep color coding: blue for .container, green for .container-fluid, purple for .container-md
- Gray background area represents screen width
- Now .container properly shows left/right margins while .container-fluid shows full width